### PR TITLE
Move PATH variable to tail for AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
+  - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
   - set CARGO_TARGET_DIR=%APPVEYOR_BUILD_FOLDER%\target
   - rustc -V
   - cargo -V


### PR DESCRIPTION
AppVeyor have `cygwin1.dll` somewhere. This PR helps to prevent future errors.

Reason: https://github.com/appveyor/ci/issues/597#issuecomment-196849776