### PR TITLE
Add environment flags for cross compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ The following Cargo features are supported:
 * `static` to link to OpenBLAS statically, and
 * `system` to skip building the bundled OpenBLAS.
 
+## Cross Compilation
+
+You'll need to specify the [cross compilation variables for OpenBLAS](
+https://github.com/xianyi/OpenBLAS#cross-compile) but with the `OPENBLAS_`
+prefix: `OPENBLAS_CC`, `OPENBLAS_FC`, `OPENBLAS_HOSTCC`, and `OPENBLAS_TARGET`.
+These can be set as environment variables for `cargo build`.
+
 ## Contribution
 
 Your contribution is highly appreciated. Do not hesitate to open an issue or a

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,9 @@
 use std::env;
-use std::path::PathBuf;
+use std::fs;
+use std::path::{
+    Path,
+    PathBuf,
+};
 use std::process::Command;
 
 macro_rules! binary(() => (if cfg!(target_pointer_width = "32") { "32" } else { "64" }));
@@ -18,21 +22,77 @@ fn main() {
         let lapacke = feature!("LAPACKE");
         let source = PathBuf::from("source");
         let output = PathBuf::from(variable!("OUT_DIR").replace(r"\", "/"));
+        // The target triple provided by cargo --target is not compatible with
+        // OpenBLAS targets.
         env::remove_var("TARGET");
-        run(
-            Command::new("make")
-                .args(&["libs", "netlib", "shared"])
-                .arg(format!("BINARY={}", binary!()))
-                .arg(format!("{}_CBLAS=1", switch!(cblas)))
-                .arg(format!("{}_LAPACKE=1", switch!(lapacke)))
-                .arg(format!("-j{}", variable!("NUM_JOBS")))
-                .current_dir(&source),
-        );
+        // The working directory for both 'make' and 'make install'
+        let make_working_dir: PathBuf;
+        let mut make_build_cmd = Command::new("make");
+        make_build_cmd
+            .args(&["libs", "netlib", "shared"])
+            .arg(format!("BINARY={}", binary!()))
+            .arg(format!("{}_CBLAS=1", switch!(cblas)))
+            .arg(format!("{}_LAPACKE=1", switch!(lapacke)))
+            .arg(format!("-j{}", variable!("NUM_JOBS")));
+        // Options for cross compilation
+        match env::var("OPENBLAS_TARGET") {
+            Ok(target) => {
+                make_build_cmd.arg(format!("TARGET={}", target));
+
+                // Since target is user-specified, we relax strictness on case.
+                let canonical_target = target.to_uppercase();
+                let canonical_target_path = Path::new(&canonical_target);
+
+                // Check if there's already a dedicated folder for compiling this target.
+                // If not, create it by duplicating the source folder.
+                if !Path::new(&canonical_target).exists() {
+                    let canonical_target_tmp = format!("{}_TMP", canonical_target);
+                    // If the tmp folder exists, the copy must have failed during
+                    // a previous invocation so remove it.
+                    let canonical_target_tmp_path = Path::new(&canonical_target_tmp);
+                    if canonical_target_tmp_path.exists() {
+                        fs::remove_dir_all(canonical_target_tmp_path).unwrap();
+                    }
+                    run(
+                        Command::new("cp")
+                            .arg("-R")
+                            .arg("source")
+                            .arg(&canonical_target_tmp)
+                    );
+                    // Remove any existing compiled files since the source folder
+                    // is still used for non-cross-compilations.
+                    run(
+                        Command::new("make")
+                            .arg("clean")
+                            .current_dir(&canonical_target_tmp_path)
+                    );
+                    // Atomic move
+                    fs::rename(canonical_target_tmp_path, canonical_target_path).unwrap();
+                }
+                make_working_dir = canonical_target_path.to_path_buf();
+            }
+            _ => {
+                make_working_dir = source.to_path_buf();
+            },
+        }
+        match env::var("OPENBLAS_CC") {
+            Ok(val) => { make_build_cmd.arg(format!("CC={}", val)); }
+            _ => {},
+        }
+        match env::var("OPENBLAS_FC") {
+            Ok(val) => { make_build_cmd.arg(format!("FC={}", val)); }
+            _ => {},
+        }
+        match env::var("OPENBLAS_HOSTCC") {
+            Ok(val) => { make_build_cmd.arg(format!("HOSTCC={}", val)); }
+            _ => {},
+        }
+        run(&mut make_build_cmd.current_dir(&make_working_dir));
         run(
             Command::new("make")
                 .arg("install")
                 .arg(format!("DESTDIR={}", output.display()))
-                .current_dir(&source),
+                .current_dir(&make_working_dir),
         );
         println!(
             "cargo:rustc-link-search={}",


### PR DESCRIPTION
I've been needing to cross compile OpenBLAS for armv7 and found this issue https://github.com/cmr/openblas-src/issues/6. Using the [cross compilation variables for OpenBLAS](https://github.com/xianyi/OpenBLAS#cross-compile) worked so this PR is more about answering how the end user should specify these variables.

It was clear that `build.rs` was going to need to be ignorant of specific tools (e.g. `arm-linux-gnueabihf-gfortran-5`). At first, I tried simply specifying all env vars to `cargo build`. However, I found that specifying a cross compilation `CC` (e.g. `arm-linux-gnueabihf-gcc`) could cause other libraries to break. `backtrace-rs` is one example: https://github.com/alexcrichton/backtrace-rs/issues/90. Also, `TARGET` is set by `cargo` to a target triple that OpenBLAS does not recognize.

To minimize the chance of conflicts, I decided to namespace all of the OpenBLAS vars needed for cross compilation with `OPENBLAS_`.

This PR works, but there's one catch. If you're compiling OpenBLAS for both your host as well as your cross compilation target, the one you do second will fail with an error that `libopenblas_haswell` is of the wrong format:

```
../libopenblas_haswellp-r0.3.0.dev.a(saxpy.o): error adding symbols: File in wrong format
```

`libopenblas_haswell` is present in the cargo cache `~/.cargo/git/checkouts/openblas-src-f808a2a33c0118e8/6af7286/source` (will be different on your machine), and is not namespaced by the target architecture. Can you contribute this fix?